### PR TITLE
docs: update README and CHANGELOG to v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to the Context module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.5.0] - 2026-04-27
+
+### Added
+
+- **AI Gateway** — new `ContextAI` class providing a centralized AI provider interface for the module and third-party modules. Access via `wire('context')->ai()`.
+- **OpenRouter support** — connect to any model available on OpenRouter (anthropic/*, openai/*, google/*, mistralai/*, etc.) using a single API key.
+- **OpenAI and custom endpoint support** — switch provider to OpenAI or any OpenAI-compatible API endpoint in module settings.
+- **`ai()->complete($prompt)`** — simple one-call text completion returning a plain string.
+- **`ai()->chat($options)`** — full chat completion with messages array, model override, temperature, max tokens.
+- **`ai()->gateway($options)`** — entry point for third-party ProcessWire modules to use the shared AI connection.
+- **`ai()->summarizePage($page)`** — built-in utility to summarize any ProcessWire page via AI.
+- **`ai()->askAboutSite($question, $contextData)`** — ask questions about the site using exported context files.
+- **Global system prompt** — set a system prompt in module settings that is prepended to every AI request from any module.
+- **OpenRouter attribution headers** — `HTTP-Referer` and `X-Title` sent automatically for proper usage tracking.
+- **AI Gateway fieldset in module settings** — provider, API key, default model, max tokens, temperature, timeout, global system prompt, and OpenRouter attribution fields. All fields use `showIf` for a clean UI.
+- **Default model**: `anthropic/claude-sonnet-4-6`.
+
 ## [1.4.3] - 2026-04-23
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Context automatically generates comprehensive documentation of your ProcessWire 
 - **Configuration** - ProcessWire version, PHP settings, installed modules
 - **Custom Classes** - Automatic detection of custom Page classes from `/site/classes/`
 - **Frontend Stack** - Auto-detects Alpine.js, Tailwind CSS, UIkit, and other frameworks
-- **ProFields Support** - Special handling for Repeater Matrix field types (if installed)
+- **ProFields Support** - Full support for Table, Combo, and Repeater Matrix field types via official APIs (if installed)
 
 ### Optional Features
 
@@ -59,6 +59,15 @@ Code snippets are automatically customized for your site type:
 - PHP 8.2 or higher
 - Write permissions for `/site/assets/context/` directory
 - No external dependencies required - pure PHP implementation
+
+
+### AI Gateway
+
+- **OpenRouter integration** — connect to Claude, GPT-4, Gemini, Mistral and 200+ models via one API key
+- **Shared gateway** — any ProcessWire module can use the AI connection via `wire('context')->ai()`
+- **Simple API** — `$ai->complete($prompt)` for quick calls, `$ai->chat($options)` for full control
+- **Global system prompt** — set once in module settings, applied to all AI requests
+- **OpenAI-compatible** — works with OpenAI directly or any compatible self-hosted endpoint
 
 ## Installation
 
@@ -96,7 +105,7 @@ Then refresh modules in admin and install.
 
 ### 2. Export Your Site
 
-Click **"Re-Export Context for AI"** or visit:
+Click **"Re-Export Context for AI"** (or **"Download Archive"** to save a ZIP of all exported files) or visit:
 ```
 /processwire/module/?name=Context
 ```
@@ -142,7 +151,7 @@ existing patterns in templates.toon.
 ├── templates.json                 # Templates (JSON)
 ├── templates.toon                 # Templates (TOON - AI optimized!)
 ├── templates.csv                  # Templates in CSV
-├── matrix-templates.json          # Repeater Matrix types (ProFields) - if installed
+├── matrix-templates.json          # Repeater Matrix types (ProFields: Table/Combo/Matrix) - if installed
 ├── matrix-templates.toon          # Repeater Matrix types (TOON) - if installed
 ├── config.json                    # Configuration (JSON)
 ├── config.toon                    # Configuration (TOON)
@@ -297,6 +306,45 @@ If you use 100 prompts/month: Save ~$13/month
 If you use 1000 prompts/month: Save ~$130/month
 ```
 
+## CLI Commands for AI Agents
+
+The module exposes a full command-line interface so AI coding agents (Claude Code, Cursor, Windsurf, Cline, etc.) can interact with ProcessWire directly from the terminal.
+
+### Export & Query
+
+```bash
+php index.php --context-export              # Full export (JSON + TOON)
+php index.php --context-export --toon-only  # TOON format only
+php index.php --context-export --json-only  # JSON format only
+
+php index.php --context-query templates     # List all templates
+php index.php --context-query fields        # List all fields
+php index.php --context-query pages         # List pages (optional selector)
+php index.php --context-stats               # Quick site statistics
+php index.php --context-help                # CLI documentation
+```
+
+### Full ProcessWire API Access
+
+```bash
+# Single-line: count pages, read fields, anything
+php index.php --context-eval 'echo $pages->count() . " pages\n";'
+
+# Multi-line: create or modify pages, templates, fields
+echo '
+$p = new Page();
+$p->template = "basic-page";
+$p->parent = $pages->get("/");
+$p->title = "New Page";
+$p->save();
+echo "Created: " . $p->url . "\n";
+' | php index.php --context-stdin
+```
+
+**Available API variables:** `$pages`, `$templates`, `$fields`, `$modules`, `$config`, `$users`, `$session`, `$input`, `$sanitizer`, `$database`, `$cache`, `$log`, `$files`, `$context`
+
+> **Security:** These commands execute with full ProcessWire privileges. Use only in development environments or with appropriate security measures.
+
 ## Auto-Update Feature
 
 Enable **Auto-Update on Changes** to automatically regenerate context when you:
@@ -380,6 +428,11 @@ Choose your site type to get customized code snippets:
 - **Auto-Update on Changes** - Auto-export on template/field save
 - **Create IDE Integration Files** - `.cursorrules`, `.claudecode.json`
 - **Custom AI Instructions** - Project-specific AI instructions
+
+### Dashboard Actions
+
+- **Re-Export Context for AI** - Regenerate all export files
+- **Download Archive** - Download entire context folder as a ZIP file (`context-{hostname}-{datetime}.zip`). Button appears after the first export.
 
 ## Technical Details
 


### PR DESCRIPTION
## Summary

- Add `[1.5.0] - 2026-04-27` entry to CHANGELOG documenting the AI Gateway (`ContextAI` class, OpenRouter/OpenAI support, shared `wire('context')->ai()` interface)
- Add **AI Gateway** section to README Features list
- Update ProFields description to reflect Table, Combo, and Repeater Matrix support via official APIs
- Add **CLI Commands for AI Agents** section covering `--context-export`, `--context-query`, `--context-stats`, `--context-eval`, and `--context-stdin` with usage examples
- Add **Download Archive** button mention in Quick Start
- Add **Dashboard Actions** subsection in Module Settings

## What a reviewer should know

All changes are documentation only — no PHP code modified. The README additions (CLI section, Dashboard Actions) document features that were implemented in v1.3.0–v1.4.3 but were missing from the README. The CHANGELOG entry mirrors what is already in the main working directory's CHANGELOG.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)